### PR TITLE
Provide docker compose

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+docker-compose-v2 (2.37.1+ds1-0ubuntu2) questing; urgency=medium
+
+  * d/control: Provide docker-compose
+
+ -- Renan Rodrigo <renanrodrigo@canonical.com>  Thu, 14 Aug 2025 09:27:38 -0300
+
 docker-compose-v2 (2.37.1+ds1-0ubuntu1) questing; urgency=medium
 
   * New upstream version 2.37.1+ds1

--- a/debian/control
+++ b/debian/control
@@ -15,6 +15,7 @@ Architecture: any
 Depends: docker.io,
          ${misc:Depends},
          ${shlibs:Depends}
+Provides: docker-compose
 Built-Using: ${libc:Built-Using}, ${misc:Built-Using}
 Description: tool for running multi-container applications on Docker
  Docker Compose is a tool for running multi-container applications on Docker


### PR DESCRIPTION
**What I did**
Added a `Provides` entry to `docker-compose` in `d/control`.

**Related issue**
In Ubuntu, the docker-compose package represents docker compose version 1. The Provides entry enables the removal of docker-compose so docker-compose-v2 becomes the default without breaking current installations or dependencies on docker-compose.

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
There you go, size 2 rabbit providing size 1 rabbit some food.
<img width="1024" height="1536" alt="rabbit" src="https://github.com/user-attachments/assets/a79056cc-d991-45c9-943b-28b872a0fe9e" />

