### PR TITLE
Demote docker.io to recommends

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,10 @@
 docker-compose-v2 (2.37.1+ds1-0ubuntu2) questing; urgency=medium
 
+  [ Renan Rodrigo ]
   * d/control: Provide docker-compose
+
+  [ Athos Ribeiro ]
+  * d/control: demote docker.io to recommends (LP: #2079929)
 
  -- Renan Rodrigo <renanrodrigo@canonical.com>  Thu, 14 Aug 2025 09:27:38 -0300
 

--- a/debian/control
+++ b/debian/control
@@ -12,9 +12,9 @@ Rules-Requires-Root: no
 
 Package: docker-compose-v2
 Architecture: any
-Depends: docker.io,
-         ${misc:Depends},
+Depends: ${misc:Depends},
          ${shlibs:Depends}
+Recommends: docker.io
 Provides: docker-compose
 Built-Using: ${libc:Built-Using}, ${misc:Built-Using}
 Description: tool for running multi-container applications on Docker


### PR DESCRIPTION
This is a fix for https://bugs.launchpad.net/ubuntu/+source/docker-compose-v2/+bug/2079929.

We should just follow Debian here and "demote" docker.io to Recommends in docker-compose-v2.

This would allow docker-compose-v2 to be used with other container runtimes, such as podman.